### PR TITLE
fixed "except" syntax for Python 3.x in reading_twitter.py

### DIFF
--- a/stem/docs/_static/example/reading_twitter.py
+++ b/stem/docs/_static/example/reading_twitter.py
@@ -81,7 +81,7 @@ try:
     print("%i. %s" % (index + 1, tweet["created_at"]))
     print(tweet["text"])
     print("")
-except IOError, exc:
+except IOError as exc:
   print(exc)
 finally:
   tor_process.kill()  # stops tor


### PR DESCRIPTION
fixed "except" syntax for Python 3.x in reading_twitter.py
(except IOError, exc:) in Python < 3.0
(except IOError as exc:) in Python >= 3.0
